### PR TITLE
Add multi-task habit calendar web app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,200 @@
+const STORAGE_KEY = 'habit-tasks';
+const COLOR_PALETTE = ['--accent-1', '--accent-2', '--accent-3', '--accent-4', '--accent-5'];
+
+const taskForm = document.querySelector('#task-form');
+const taskNameInput = document.querySelector('#task-name');
+const tasksContainer = document.querySelector('#tasks-container');
+const taskTemplate = document.querySelector('#task-template');
+
+let tasks = loadTasks();
+const viewState = new Map();
+
+function loadTasks() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return [];
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error('加载任务失败', error);
+    return [];
+  }
+}
+
+function saveTasks() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+function createTask(name) {
+  const colorIndex = tasks.length % COLOR_PALETTE.length;
+  const id = typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `task-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return {
+    id,
+    name,
+    color: COLOR_PALETTE[colorIndex],
+    records: [],
+  };
+}
+
+function formatDate(date) {
+  return [date.getFullYear(), String(date.getMonth() + 1).padStart(2, '0'), String(date.getDate()).padStart(2, '0')].join('-');
+}
+
+function renderTasks() {
+  tasksContainer.innerHTML = '';
+
+  if (!tasks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-tip';
+    empty.textContent = '还没有任务，先添加一个打卡任务吧！';
+    tasksContainer.appendChild(empty);
+    return;
+  }
+
+  tasks.forEach((task, index) => {
+    const node = taskTemplate.content.firstElementChild.cloneNode(true);
+    const titleEl = node.querySelector('.task-card__title');
+    const todayBtn = node.querySelector('.task-card__today');
+    const deleteBtn = node.querySelector('.task-card__delete');
+    const prevBtn = node.querySelector('.calendar__nav--prev');
+    const nextBtn = node.querySelector('.calendar__nav--next');
+    const labelEl = node.querySelector('.calendar__label');
+    const gridEl = node.querySelector('.calendar__grid');
+
+    titleEl.textContent = task.name;
+    const color = getColorValue(task.color);
+    node.style.setProperty('--task-color', color);
+
+    const { year, month } = getViewMonth(task.id);
+    renderCalendar(task, year, month, labelEl, gridEl);
+
+    prevBtn.addEventListener('click', () => {
+      const { year: currentYear, month: currentMonth } = getViewMonth(task.id);
+      const prevDate = new Date(currentYear, currentMonth - 1, 1);
+      setViewMonth(task.id, prevDate.getFullYear(), prevDate.getMonth());
+      renderCalendar(task, prevDate.getFullYear(), prevDate.getMonth(), labelEl, gridEl);
+    });
+
+    nextBtn.addEventListener('click', () => {
+      const { year: currentYear, month: currentMonth } = getViewMonth(task.id);
+      const nextDate = new Date(currentYear, currentMonth + 1, 1);
+      setViewMonth(task.id, nextDate.getFullYear(), nextDate.getMonth());
+      renderCalendar(task, nextDate.getFullYear(), nextDate.getMonth(), labelEl, gridEl);
+    });
+
+    todayBtn.addEventListener('click', () => {
+      toggleRecord(task, new Date());
+      const { year: viewYear, month: viewMonth } = getViewMonth(task.id);
+      renderCalendar(task, viewYear, viewMonth, labelEl, gridEl);
+    });
+
+    deleteBtn.addEventListener('click', () => {
+      if (confirm(`确定删除任务「${task.name}」吗？`)) {
+        tasks = tasks.filter((item) => item.id !== task.id);
+        viewState.delete(task.id);
+        saveTasks();
+        renderTasks();
+      }
+    });
+
+    tasksContainer.appendChild(node);
+  });
+}
+
+function renderCalendar(task, year, month, labelEl, gridEl) {
+  const displayDate = new Date(year, month, 1);
+  const monthLabel = `${displayDate.getFullYear()}年${displayDate.getMonth() + 1}月`;
+  labelEl.textContent = monthLabel;
+
+  gridEl.innerHTML = '';
+
+  const firstDay = new Date(year, month, 1);
+  const startDay = firstDay.getDay(); // Sunday = 0
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const prevMonthDays = startDay; // number of days from previous month to fill first week
+  const totalCells = Math.ceil((prevMonthDays + daysInMonth) / 7) * 7;
+
+  for (let cellIndex = 0; cellIndex < totalCells; cellIndex++) {
+    const cell = document.createElement('div');
+    cell.className = 'calendar__cell';
+    const content = document.createElement('div');
+    content.className = 'calendar__cell-content';
+
+    const dateOffset = cellIndex - prevMonthDays + 1;
+    const cellDate = new Date(year, month, dateOffset);
+    const isCurrentMonth = cellDate.getMonth() === month;
+
+    if (!isCurrentMonth) {
+      cell.classList.add('is-out-month');
+    }
+
+    if (isCurrentMonth && dateOffset > 0 && dateOffset <= daysInMonth) {
+      content.textContent = dateOffset;
+      cell.dataset.date = formatDate(cellDate);
+      if (task.records.includes(cell.dataset.date)) {
+        cell.classList.add('is-checked');
+      }
+      cell.addEventListener('click', () => {
+        toggleRecord(task, cellDate);
+        renderCalendar(task, year, month, labelEl, gridEl);
+      });
+    } else {
+      content.textContent = cellDate.getDate();
+    }
+
+    cell.appendChild(content);
+    gridEl.appendChild(cell);
+  }
+}
+
+function toggleRecord(task, date) {
+  const dateKey = formatDate(date);
+  const hasRecord = task.records.includes(dateKey);
+
+  if (hasRecord) {
+    task.records = task.records.filter((item) => item !== dateKey);
+  } else {
+    task.records.push(dateKey);
+    task.records.sort();
+  }
+
+  saveTasks();
+}
+
+function getColorValue(varName) {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(varName);
+  return value ? value.trim() : '#4a6cf7';
+}
+
+function getViewMonth(taskId) {
+  if (!viewState.has(taskId)) {
+    const now = new Date();
+    viewState.set(taskId, { year: now.getFullYear(), month: now.getMonth() });
+  }
+  return viewState.get(taskId);
+}
+
+function setViewMonth(taskId, year, month) {
+  viewState.set(taskId, { year, month });
+}
+
+function init() {
+  taskForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const name = taskNameInput.value.trim();
+    if (!name) return;
+
+    const newTask = createTask(name);
+    tasks.push(newTask);
+    saveTasks();
+    taskNameInput.value = '';
+    renderTasks();
+  });
+
+  renderTasks();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>多任务打卡日历</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>多任务打卡</h1>
+        <form id="task-form" class="task-form">
+          <input
+            type="text"
+            id="task-name"
+            placeholder="输入任务名称，例如：晨跑"
+            aria-label="任务名称"
+            required
+            maxlength="30"
+          />
+          <button type="submit">添加任务</button>
+        </form>
+      </header>
+
+      <section id="tasks-container" class="tasks"></section>
+    </main>
+
+    <template id="task-template">
+      <article class="task-card">
+        <header class="task-card__header">
+          <h2 class="task-card__title"></h2>
+          <div class="task-card__actions">
+            <button type="button" class="task-card__today">今日打卡</button>
+            <button type="button" class="task-card__delete" aria-label="删除任务">删除</button>
+          </div>
+        </header>
+        <div class="task-card__calendar">
+          <div class="calendar__controls">
+            <button type="button" class="calendar__nav calendar__nav--prev" aria-label="上一月">‹</button>
+            <div class="calendar__label"></div>
+            <button type="button" class="calendar__nav calendar__nav--next" aria-label="下一月">›</button>
+          </div>
+          <div class="calendar__weekdays">
+            <span>日</span>
+            <span>一</span>
+            <span>二</span>
+            <span>三</span>
+            <span>四</span>
+            <span>五</span>
+            <span>六</span>
+          </div>
+          <div class="calendar__grid"></div>
+        </div>
+      </article>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,250 @@
+:root {
+  --bg: #f5f6fa;
+  --card-bg: #ffffff;
+  --primary: #4a6cf7;
+  --text: #1e1e2f;
+  --muted: #707070;
+  --border-radius: 16px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  --accent-1: #4a6cf7;
+  --accent-2: #f75c4a;
+  --accent-3: #34c759;
+  --accent-4: #ff9f1c;
+  --accent-5: #a855f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+  background: linear-gradient(160deg, #eff3ff, #fdf2f8);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px 80px;
+}
+
+.app__header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.app__header h1 {
+  margin: 0 0 16px;
+  font-size: 2rem;
+}
+
+.task-form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.task-form input {
+  flex: 1 1 240px;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(74, 108, 247, 0.2);
+  font-size: 1rem;
+  outline: none;
+}
+
+.task-form input:focus {
+  box-shadow: inset 0 0 0 2px rgba(74, 108, 247, 0.6);
+}
+
+.task-form button {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 20px rgba(74, 108, 247, 0.25);
+}
+
+.task-form button:hover {
+  transform: translateY(-1px);
+}
+
+.tasks {
+  display: grid;
+  gap: 24px;
+}
+
+.task-card {
+  --task-color: var(--primary);
+  background: var(--card-bg);
+  border-radius: var(--border-radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.task-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.task-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.task-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.task-card__actions button {
+  border: none;
+  border-radius: 12px;
+  padding: 8px 14px;
+  background: rgba(74, 108, 247, 0.1);
+  color: var(--primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.task-card__actions button:hover {
+  background: rgba(74, 108, 247, 0.2);
+  transform: translateY(-1px);
+}
+
+.task-card__actions .task-card__delete {
+  background: rgba(247, 92, 74, 0.15);
+  color: #f75c4a;
+}
+
+.task-card__actions .task-card__delete:hover {
+  background: rgba(247, 92, 74, 0.25);
+}
+
+.calendar__controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.calendar__label {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calendar__nav {
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+.calendar__nav:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.calendar__weekdays,
+.calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+}
+
+.calendar__weekdays {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.calendar__grid {
+  min-height: 280px;
+}
+
+.calendar__cell {
+  position: relative;
+  padding-top: 100%;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.03);
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar__cell.is-out-month {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.calendar__cell:hover:not(.is-out-month) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.12);
+}
+
+.calendar__cell-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.calendar__cell.is-checked {
+  background: var(--task-color);
+  color: #fff;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.15);
+}
+
+.calendar__cell.is-checked .calendar__cell-content {
+  color: #fff;
+}
+
+.empty-tip {
+  margin: 0;
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+}
+
+@media (min-width: 768px) {
+  .tasks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .tasks {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive H5 page for managing multiple habit tasks with monthly calendars
- implement localStorage persistence and per-day toggle for punch-in records
- style calendars with vibrant task-specific colors and provide task actions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcc10ab2608323b90deda3dcedcc6c