### PR TITLE
Add local SQLite database helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # codex
+
+This repository provides a lightweight helper for persisting structured data to
+an on-disk SQLite database.  The :class:`LocalFileDatabase` utility handles
+initialising the database file, inserting JSON-serialised payloads, fetching
+records, and clearing stored entries.
+
+## Quick start
+
+```python
+from local_file_database import LocalFileDatabase
+
+# create (or connect to) the local SQLite database
+storage = LocalFileDatabase("measurements.sqlite")
+
+# store some structured data
+storage.record({"temperature": 21.5, "unit": "C"})
+
+# retrieve all stored rows
+for record in storage.fetch_records():
+    print(record)
+```
+
+Run the automated test-suite with:
+
+```bash
+pytest
+```

--- a/local_file_database.py
+++ b/local_file_database.py
@@ -1,0 +1,204 @@
+"""Local file-backed database helper utilities.
+
+This module exposes :class:`LocalFileDatabase`, a thin wrapper over
+:mod:`sqlite3` that persists data to a database stored on the local
+filesystem.  The goal is to make it straightforward to record arbitrary
+Python dictionaries in situations where a lightweight, embedded storage
+solution is sufficient.
+
+Example
+-------
+
+>>> db = LocalFileDatabase("my-data.db")
+>>> db.record({"temperature": 21.5, "unit": "C"})
+1
+>>> db.fetch_records()
+[{'id': 1, 'data': {'temperature': 21.5, 'unit': 'C'}, ... }]
+
+The implementation keeps the schema intentionally small – every record is
+stored as JSON alongside its creation timestamp.  The timestamp uses
+``datetime.isoformat`` and is normalised to UTC by default.  Consumers can
+limit or page through the stored entries using :meth:`fetch_records`.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
+
+JsonMapping = Mapping[str, Any]
+
+
+class LocalFileDatabase:
+    """Persist structured data inside a SQLite database stored on disk.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the SQLite database file.  Parent directories are
+        created automatically if they do not exist yet.
+    """
+
+    def __init__(self, path: Union[str, Path] = "data.db") -> None:
+        self._path = Path(path).expanduser()
+        self._ensure_parent_directory()
+        self._initialise()
+
+    @property
+    def path(self) -> Path:
+        """Return the path of the backing SQLite database file."""
+
+        return self._path
+
+    def record(
+        self,
+        data: JsonMapping,
+        *,
+        created_at: Optional[datetime] = None,
+    ) -> int:
+        """Insert a new record into the database.
+
+        Parameters
+        ----------
+        data:
+            Mapping of JSON-serialisable values that should be persisted.
+        created_at:
+            Optional timestamp.  When omitted the current UTC timestamp is
+            used.
+
+        Returns
+        -------
+        int
+            The numeric identifier of the newly inserted row.
+        """
+
+        if not isinstance(data, Mapping):  # type: ignore[arg-type]
+            raise TypeError("data must be a mapping")
+
+        payload = json.dumps(data, default=_json_default, ensure_ascii=False)
+        timestamp = _normalise_timestamp(created_at)
+
+        with self._connection() as connection:
+            cursor = connection.execute(
+                "INSERT INTO records (payload, created_at) VALUES (?, ?)",
+                (payload, timestamp),
+            )
+            return int(cursor.lastrowid)
+
+    def fetch_records(
+        self,
+        *,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        descending: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Return stored records as a list of dictionaries.
+
+        Parameters
+        ----------
+        limit:
+            Maximum number of rows to return.  ``None`` returns all rows.
+        offset:
+            Number of initial rows to skip.  Useful for pagination.
+        descending:
+            When ``True`` rows are returned in reverse chronological order.
+        """
+
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be non-negative or None")
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
+
+        order = "DESC" if descending else "ASC"
+        query = f"SELECT id, payload, created_at FROM records ORDER BY id {order}"
+        parameters: List[Union[int, str]] = []
+        if limit is not None or offset:
+            limit_value = limit if limit is not None else -1
+            query += " LIMIT ? OFFSET ?"
+            parameters.extend([limit_value, offset])
+
+        with self._connection() as connection:
+            connection.row_factory = sqlite3.Row
+            rows = connection.execute(query, parameters)
+            return [
+                {
+                    "id": row["id"],
+                    "data": json.loads(row["payload"]),
+                    "created_at": row["created_at"],
+                }
+                for row in rows
+            ]
+
+    def clear(self) -> None:
+        """Delete all stored records from the database."""
+
+        with self._connection() as connection:
+            connection.execute("DELETE FROM records")
+
+    def count(self) -> int:
+        """Return the total number of stored records."""
+
+        with self._connection() as connection:
+            cursor = connection.execute("SELECT COUNT(*) FROM records")
+            (count,) = cursor.fetchone()  # type: ignore[misc]
+            return int(count)
+
+    def _ensure_parent_directory(self) -> None:
+        parent = self._path.resolve().parent
+        parent.mkdir(parents=True, exist_ok=True)
+
+    def _initialise(self) -> None:
+        with self._connection() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS records (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection = sqlite3.connect(str(self._path))
+        try:
+            yield connection
+            connection.commit()
+        finally:
+            connection.close()
+
+
+def _json_default(value: Any) -> Any:
+    """Best-effort JSON serialization helper.
+
+    ``json.dumps`` calls the ``default`` callback for unsupported objects.
+    ``datetime`` instances are serialised using :meth:`datetime.isoformat`,
+    :class:`Path` objects use :func:`str`, and everything else is passed through
+    unchanged which lets :mod:`json` raise a ``TypeError`` for unsupported
+    values.
+    """
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _normalise_timestamp(timestamp: Optional[datetime]) -> str:
+    """Return an ISO-8601 timestamp string.
+
+    ``None`` values fall back to the current time in UTC.
+    """
+
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc).isoformat()
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_local_file_database.py
+++ b/tests/test_local_file_database.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from local_file_database import LocalFileDatabase
+
+
+def test_record_and_fetch_roundtrip(tmp_path):
+    db_path = tmp_path / "records.db"
+    database = LocalFileDatabase(db_path)
+
+    first_id = database.record({"temperature": 21.5, "unit": "C"})
+    second_timestamp = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    second_id = database.record({"humidity": 0.58}, created_at=second_timestamp)
+
+    records = database.fetch_records()
+    assert [record["id"] for record in records] == [first_id, second_id]
+    assert records[0]["data"] == {"temperature": 21.5, "unit": "C"}
+    assert records[1]["created_at"].startswith("2020-01-01T00:00:00+00:00")
+
+    assert db_path.exists(), "database file should be created on disk"
+
+
+def test_fetch_with_limit_and_offset(tmp_path):
+    database = LocalFileDatabase(tmp_path / "db.sqlite")
+
+    for index in range(5):
+        database.record({"index": index})
+
+    limited = database.fetch_records(limit=2)
+    assert len(limited) == 2
+    assert [record["data"]["index"] for record in limited] == [0, 1]
+
+    paged = database.fetch_records(limit=2, offset=2)
+    assert len(paged) == 2
+    assert [record["data"]["index"] for record in paged] == [2, 3]
+
+    descending = database.fetch_records(descending=True)
+    assert [record["data"]["index"] for record in descending] == [4, 3, 2, 1, 0]
+
+
+def test_clear_and_count(tmp_path):
+    database = LocalFileDatabase(tmp_path / "storage.sqlite")
+
+    database.record({"value": 1})
+    database.record({"value": 2})
+
+    assert database.count() == 2
+
+    database.clear()
+    assert database.count() == 0
+    assert database.fetch_records() == []
+
+
+def test_record_requires_mapping(tmp_path):
+    database = LocalFileDatabase(tmp_path / "db.sqlite")
+
+    with pytest.raises(TypeError):
+        database.record([("key", "value")])  # type: ignore[arg-type]
+
+
+def test_custom_json_serialisation(tmp_path):
+    database = LocalFileDatabase(tmp_path / "custom.sqlite")
+
+    timestamp = datetime(2023, 3, 8, tzinfo=timezone.utc)
+    payload_path = Path("/tmp/data.txt")
+
+    record_id = database.record({
+        "timestamp": timestamp,
+        "path": payload_path,
+    })
+
+    [record] = database.fetch_records()
+    assert record["id"] == record_id
+    assert record["data"]["timestamp"] == timestamp.isoformat()
+    assert record["data"]["path"] == str(payload_path)


### PR DESCRIPTION
## Summary
- add a `LocalFileDatabase` helper that persists mapping payloads to an on-disk SQLite database
- cover database behaviour with tests for CRUD operations, pagination, and JSON serialisation
- document the new utility and quick-start instructions in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc26e35e883238d1f90cd44d7f7e1